### PR TITLE
revert postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:dev": "nodemon --watch test --exec \"playwright test\" -e ts",
     "test:start": "NODE_ENV=test start-server-and-test start:proxy http://localhost:3000/health-check/app test",
     "test:start:all": "NODE_ENV=test start-server-and-test start:proxy http://localhost:3000/health-check/app test:all",
-    "postinstall": "yarn build"
+    "postinstall": "yarn prisma generate"
   },
   "dependencies": {
     "handlebars": "^4.7.7",


### PR DESCRIPTION
Since we have all of the dependencies here we can revert the build script back to what it use to do. 